### PR TITLE
Fix for TypeError: Cannot read property 'properties' of null #25

### DIFF
--- a/src/html-to-doc.js
+++ b/src/html-to-doc.js
@@ -85,7 +85,7 @@ function getSectionHeaders(markdown) {
   const emitCurrent = () => {
     result.push({
       title: toText(currentSection).replace(/^#+/, '').replace(/#$/, ''),
-      ref: select('.anchor', currentSection).properties.id,
+      ref: select('.anchor', currentSection)?.properties.id,
       content: contentsAcc,
     })
     contentsAcc = ''


### PR DESCRIPTION
Got same error as in issue #25 
Exception happens when building docusaurus and there are h2/h3 titles.

Here is a quick fix to prevent exception, if `select` returns undefined.