### PR TITLE
fix: lunr.TinySegmenter of lang ja #47

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,10 @@ function generateLunrClientJS(outDir, language = "en") {
             language
                 .filter(code => code !== "en")
                 .forEach(code => {
+                    if (code === 'ja' || code === 'jp') {
+                        require("lunr-languages/tinyseg")(lunr);
+                        lunrClient += 'require("lunr-languages/tinyseg")(lunr);\n';
+                    }
                     require(`lunr-languages/lunr.${code}`)(lunr);
                     lunrClient += `require("lunr-languages/lunr.${code}")(lunr);\n`;
                 });


### PR DESCRIPTION
fix #47

ref.
https://github.com/MihaiValentin/lunr-languages/blob/a62fec97fb1a62bb4581c9b69a5ddedf62f8f62f/lunr.ja.js#L86

For the ja language on the `lunr-language` side, it is assumed that the `lunr` object has `TinySegmenter`. So, load `tinyseg` when language is ja.