### PR TITLE
Fix browser cache inconsistency issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,13 @@ const utils = require('./utils')
 module.exports = function (context, options) {
   options = options || {};
   let languages
+
+  const guid = String(Date.now())
+  const fileNames = {
+    searchDoc: `search-doc-${guid}.json`,
+    lunrIndex: `lunr-index-${guid}.json`,
+  }
+
   return {
     name: 'docusaurus-lunr-search',
     getThemePath() {
@@ -36,6 +43,9 @@ module.exports = function (context, options) {
           },
         },
       };
+    },
+    async contentLoaded({actions}) {
+      actions.setGlobalData({"fileNames": fileNames})
     },
     async postBuild({ routesPaths = [], outDir, baseUrl }) {
       console.log('docusaurus-lunr-search:: Building search docs and lunr index file')
@@ -78,15 +88,30 @@ module.exports = function (context, options) {
       console.timeEnd('docusaurus-lunr-search:: Indexing time')
       console.log(`docusaurus-lunr-search:: indexed ${indexedDocuments} documents out of ${files.length}`)
       
+      const searchDocFileContents = JSON.stringify(searchDocuments)
       console.log('docusaurus-lunr-search:: writing search-doc.json')
+      // This file is written for backwards-compatibility with components swizzled from v2.1.12 or earlier.
       fs.writeFileSync(
         path.join(outDir, 'search-doc.json'),
-        JSON.stringify(searchDocuments)
+        searchDocFileContents
       )
+      console.log(`docusaurus-lunr-search:: writing ${fileNames.searchDoc}`)
+      fs.writeFileSync(
+        path.join(outDir, fileNames.searchDoc),
+        searchDocFileContents
+      )
+
+      const lunrIndexFileContents = JSON.stringify(lunrIndex);
       console.log('docusaurus-lunr-search:: writing lunr-index.json')
+      // This file is written for backwards-compatibility with components swizzled from v2.1.12 or earlier.
       fs.writeFileSync(
         path.join(outDir, 'lunr-index.json'),
-        JSON.stringify(lunrIndex)
+        lunrIndexFileContents
+      )
+      console.log(`docusaurus-lunr-search:: writing ${fileNames.lunrIndex}`)
+      fs.writeFileSync(
+        path.join(outDir, fileNames.lunrIndex),
+        lunrIndexFileContents
       )
       console.log('docusaurus-lunr-search:: End of process')
     },

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -9,6 +9,7 @@ import React, { useRef, useCallback } from "react";
 import classnames from "classnames";
 import { useHistory } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { usePluginData } from '@docusaurus/useGlobalData';
 const Search = props => {
   const initialized = useRef(false);
   const searchBarRef = useRef(null);
@@ -36,14 +37,15 @@ const Search = props => {
       });
   };
 
+  const pluginData = usePluginData('docusaurus-lunr-search');
   const getSearchDoc = () =>
     process.env.NODE_ENV === "production"
-      ? fetch(`${baseUrl}search-doc.json`).then((content) => content.json())
+      ? fetch(`${baseUrl}${pluginData.fileNames.searchDoc}`).then((content) => content.json())
       : Promise.resolve([]);
 
   const getLunrIndex = () =>
     process.env.NODE_ENV === "production"
-      ? fetch(`${baseUrl}lunr-index.json`).then((content) => content.json())
+      ? fetch(`${baseUrl}${pluginData.fileNames.lunrIndex}`).then((content) => content.json())
       : Promise.resolve([]);
 
   const loadAlgolia = () => {


### PR DESCRIPTION
Thanks for this plugin! I think it's great!

I noticed that the browser can cache the `search-doc.json` and `lunr-index.json` files, causing problems presumably when they don't match each other. This results in a broken experience when what you type returns the wrong results, and highlights incorrect parts of the results.

Example:
<img width="553" alt="Screenshot 2021-04-22 at 17 40 14" src="https://user-images.githubusercontent.com/692011/115752254-d390ce00-a391-11eb-80e3-5ddd9a55b4f9.png">

So I've fixed it by generating a unique id (just a millisecond timestamp) for each build of the site, and including this id in the file names. This way, a given instance of the site will always request the version of these files that match - whether they are cached or not, the correct one will be received.

---

To avoid breaking compatibility with sites that have already swizzled the SearchBar component, I've left it still generating the non-uniquely named files, so requests for those will still succeed. But newly swizzled components will now request unique versions, and not suffer cache issues.

I've tested  this change on a test site:

With a component swizzled before this change, the old named files are requested and succeed:

<img width="546" alt="Screenshot 2021-04-22 at 17 29 17" src="https://user-images.githubusercontent.com/692011/115752914-7ba69700-a392-11eb-87a4-2a29794b6c6b.png">

With a component swizzled after this change, the new unique names are used, and succeed.
<img width="519" alt="Screenshot 2021-04-22 at 17 35 34" src="https://user-images.githubusercontent.com/692011/115752906-78aba680-a392-11eb-8860-94dbc9e81bc3.png">
