### PR TITLE
fix: Stop search in local development

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,27 +16,6 @@ module.exports = function (context, options) {
     getThemePath() {
       return path.resolve(__dirname, './theme');
     },
-    configureWebpack(config) {
-      const generatedFilesDir = config.resolve.alias['@generated']
-      languages = utils.generateLunrClientJS(generatedFilesDir, options.languages);
-      // Ensure that algolia docsearch css is its own chunk
-      return {
-        optimization: {
-          splitChunks: {
-            cacheGroups: {
-              algolia: {
-                name: 'algolia',
-                test: /algolia\.css$/,
-                chunks: `all`,
-                enforce: true,
-                // Set priority higher than docusaurus single-css extraction
-                priority: 60,
-              },
-            },
-          },
-        },
-      };
-    },
     async postBuild({ routesPaths = [], outDir, baseUrl }) {
       console.log('docusaurus-lunr-search:: Building search docs and lunr index file')
       console.time('docusaurus-lunr-search:: Indexing time')

--- a/src/theme/SearchBar/algolia.css
+++ b/src/theme/SearchBar/algolia.css
@@ -531,3 +531,19 @@
   margin-left: auto;
   margin-right: 5px;
 }
+
+
+html[data-theme='dark'] .algolia-docsearch-suggestion--category-header,
+html[data-theme='dark'] .algolia-docsearch-suggestion--wrapper,
+html[data-theme='dark'] .algolia-docsearch-footer {
+    background: var(--ifm-background-color);
+    color: var(--ifm-font-color-base);
+}
+
+html[data-theme='dark'] .algolia-docsearch-suggestion--title {
+    color: var(--ifm-font-color-base);
+}
+
+html[data-theme='dark'] .ds-cursor .algolia-docsearch-suggestion--wrapper {
+    background: var(--ifm-background-surface-color);
+}

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -54,6 +54,9 @@ const Search = props => {
         import("./lib/DocSearch"),
         import("./algolia.css")
       ]).then(([searchDocs, searchIndex, { default: DocSearch }]) => {
+        if( searchDocs.length === 0) {
+          return;
+        }
         initAlgolia(searchDocs, searchIndex, DocSearch);
       });
       initialized.current = true;

--- a/src/theme/SearchBar/lib/lunar-search.js
+++ b/src/theme/SearchBar/lib/lunar-search.js
@@ -1,4 +1,4 @@
-import lunr from "@generated/lunr.client";
+import * as lunr from "lunr";
 lunr.tokenizer.separator = /[\s\-/]+/;
 
 class LunrSearchAdapter {


### PR DESCRIPTION
If you hover the search, the web crashes in development `yarn start/npm run start`. Check if an searchDocs exist and return then 0 indexes are loaded.