### PR TITLE
Load search index on initial render

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useRef, useCallback } from "react";
+import React, { useRef, useCallback, useState } from "react";
 import classnames from "classnames";
 import { useHistory } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -13,8 +13,9 @@ import { usePluginData } from '@docusaurus/useGlobalData';
 const Search = props => {
   const initialized = useRef(false);
   const searchBarRef = useRef(null);
+  const [indexReady, setIndexReady] = useState(false);
   const history = useHistory();
-  const { siteConfig = {} } = useDocusaurusContext();
+  const { siteConfig = {}, isClient = false} = useDocusaurusContext();
   const { baseUrl } = siteConfig;
   const initAlgolia = (searchDocs, searchIndex, DocSearch) => {
       new DocSearch({
@@ -60,6 +61,7 @@ const Search = props => {
           return;
         }
         initAlgolia(searchDocs, searchIndex, DocSearch);
+        setIndexReady(true);
       });
       initialized.current = true;
     }
@@ -76,6 +78,10 @@ const Search = props => {
     [props.isSearchBarExpanded]
   );
 
+  if (isClient) {
+    loadAlgolia();
+  }
+
   return (
     <div className="navbar__search" key="search-box">
       <span
@@ -91,7 +97,7 @@ const Search = props => {
       <input
         id="search_input_react"
         type="search"
-        placeholder="Search"
+        placeholder={indexReady ? 'Search' : 'Loading...'}
         aria-label="Search"
         className={classnames(
           "navbar__search-input",
@@ -103,6 +109,7 @@ const Search = props => {
         onFocus={toggleSearchIconClick}
         onBlur={toggleSearchIconClick}
         ref={searchBarRef}
+        disabled={!indexReady}
       />
     </div>
   );


### PR DESCRIPTION
I've noticed that on slow internet connections, or when the search index is large, there's a bug.

Currently the search index is loaded when you hover over the search bar.
You can still type while it's loading, and then when the request completes, the search bar re-renders and you lose focus, which is really disruptive. You then have to modify the query a bit to get the results to show.

Here's a video demonstrating the issue when adding the plugin to the official docusaurus site, and with speed throttling on: https://vimeo.com/575802281

I'm attaching the fix that I have been using for this, though I'm aware you may not want to do this. The correct fix is probably better state management / avoiding re-renders, but tbh, I'm not sure where that problem lies.

The way this fix works is by starting off the search bar as disabled, and immediately kicking off a load to the index, then enabling the search bar when it's loaded. This works nicely for me.