### PR TITLE
Fix indexing not working and SearchBar not working after some backwards-incompatible docusaurus changes

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -27,7 +27,7 @@ const Search = props => {
         // Override algolia's default selection event, allowing us to do client-side
         // navigation and avoiding a full page refresh.
         handleSelected: (_input, _event, suggestion) => {
-          const url = baseUrl + suggestion.url;
+          const url = suggestion.url ? baseUrl + suggestion.url : "/";
           // Use an anchor tag to parse the absolute url into a relative url
           // Alternatively, we can use new URL(suggestion.url) but its not supported in IE
           const a = document.createElement("a");

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -10,12 +10,14 @@ import classnames from "classnames";
 import { useHistory } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { usePluginData } from '@docusaurus/useGlobalData';
+import useIsBrowser from "@docusaurus/useIsBrowser";
 const Search = props => {
   const initialized = useRef(false);
   const searchBarRef = useRef(null);
   const [indexReady, setIndexReady] = useState(false);
   const history = useHistory();
-  const { siteConfig = {}, isClient = false} = useDocusaurusContext();
+  const { siteConfig = {} } = useDocusaurusContext();
+  const isBrowser = useIsBrowser();
   const { baseUrl } = siteConfig;
   const initAlgolia = (searchDocs, searchIndex, DocSearch) => {
       new DocSearch({
@@ -78,7 +80,7 @@ const Search = props => {
     [props.isSearchBarExpanded]
   );
 
-  if (isClient) {
+  if (isBrowser) {
     loadAlgolia();
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,9 +61,19 @@ function getFilePaths(routesPaths, outDir, baseUrl, options = {}) {
     }
 
     routesPaths.forEach((route) => {
-        if ((!indexBaseUrl && route === baseUrl) || route === `${baseUrl}404.html`) return
-        route = route.substr(baseUrl.length)
-        const filePath = path.join(outDir, route, "index.html")
+        if (route === `${baseUrl}404.html`) return
+        let filePath;
+        if (route === baseUrl) {
+            if (!indexBaseUrl) {
+                return;
+            }
+            // Special case for index.html
+            route = route.substr(baseUrl.length)
+            filePath = path.join(outDir, route, "index.html")
+        } else {
+            route = route.substr(baseUrl.length)
+            filePath = path.join(outDir, `${route}.html`)
+        }
         // In case docs only mode routesPaths has baseUrl twice
         if(addedFiles.has(filePath)) return
         if (excludeRoutes.some((excludePattern) => minimatch(route, excludePattern))) {


### PR DESCRIPTION
Due to https://github.com/facebook/docusaurus/pull/5349, SearchBar is no longer fetching the index file on initialization because isClient has been removed.

There seems to have been a second change for the output files of the production builds so instead of `/foo/index.html`, they are now `/foo.html`. This PR updates the file scanning logic to account for that.