### PR TITLE
Absolute suggestions URLs

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -21,11 +21,12 @@ const Search = props => {
       new DocSearch({
         searchDocs,
         searchIndex,
+        baseUrl,
         inputSelector: "#search_input_react",
         // Override algolia's default selection event, allowing us to do client-side
         // navigation and avoiding a full page refresh.
         handleSelected: (_input, _event, suggestion) => {
-          const url = baseUrl + suggestion.url;
+          const url = suggestion.url;
           // Use an anchor tag to parse the absolute url into a relative url
           // Alternatively, we can use new URL(suggestion.url) but its not supported in IE
           const a = document.createElement("a");
@@ -57,7 +58,7 @@ const Search = props => {
         import("./lib/DocSearch"),
         import("./algolia.css")
       ]).then(([searchDocs, searchIndex, { default: DocSearch }]) => {
-        if( searchDocs.length === 0) {
+        if (searchDocs.length === 0) {
           return;
         }
         initAlgolia(searchDocs, searchIndex, DocSearch);

--- a/src/theme/SearchBar/lib/DocSearch.js
+++ b/src/theme/SearchBar/lib/DocSearch.js
@@ -21,6 +21,7 @@ class DocSearch {
         searchIndex,
         inputSelector,
         debug = false,
+        baseUrl = '/',
         queryDataCallback = null,
         autocompleteOptions = {
             debug: false,
@@ -55,7 +56,7 @@ class DocSearch {
 
         this.isSimpleLayout = layout === "simple";
 
-        this.client = new LunrSearchAdapter(searchDocs, searchIndex);
+        this.client = new LunrSearchAdapter(searchDocs, searchIndex, baseUrl);
 
         if (enhancedSearchInput) {
             this.input = DocSearch.injectSearchBox(this.input);

--- a/src/theme/SearchBar/lib/lunar-search.js
+++ b/src/theme/SearchBar/lib/lunar-search.js
@@ -2,9 +2,10 @@ import lunr from "@generated/lunr.client";
 lunr.tokenizer.separator = /[\s\-/]+/;
 
 class LunrSearchAdapter {
-    constructor(searchDocs, searchIndex) {
+    constructor(searchDocs, searchIndex, baseUrl = '/') {
         this.searchDocs = searchDocs;
         this.lunrIndex = lunr.Index.load(searchIndex);
+        this.baseUrl = baseUrl;
     }
 
     getLunrResult(input) {
@@ -25,7 +26,7 @@ class LunrSearchAdapter {
                 lvl0: doc.pageTitle || doc.title,
                 lvl1: doc.type === 0 ? null : doc.title
             },
-            url: doc.url,
+            url: this.baseUrl + doc.url,
             _snippetResult: formattedContent ? {
                 content: {
                     value: formattedContent,


### PR DESCRIPTION
I stumbled upon a problem with opening search suggestions in a new tab when one of the pages is opened. When I tried to open one I was getting the "Page not found" error. The issue can be reproduced in your own demo. Like this:

https://user-images.githubusercontent.com/21964985/143767162-d253690c-c613-4027-a5a3-06a6f29c4096.mp4

It happens because the suggestion's URL is relative and it's appended in the end of the current URL. So instead of opening `/docusaurus-lunr-search-multilang/docs/doc1` it opens `/docusaurus-lunr-search-multilang/docs/doc1/docs/doc2`.

Prepending the `baseUrl` from Docusaurus's config in the `LunrSearchAdapter.getHit()` method solves this issue. I already applied the same changes to my own website on a swizzled component.